### PR TITLE
Add Prisma generate to build and postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
+  "dev": "next dev --turbo",
+  "build": "prisma generate && next build",
+  "start": "next start",
+  "lint": "next lint",
+  "postinstall": "prisma generate"
+},
   "dependencies": {
     "@prisma/client": "^6.12.0",
     "@radix-ui/react-label": "^2.1.7",


### PR DESCRIPTION
Updated the build script to run 'prisma generate' before building and added a postinstall script to ensure Prisma client is generated after dependencies are installed.