### PR TITLE
Set archive page to force dynamic rendering - stop cache issues

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { prisma } from '@/lib/db';
 import PoemsClient from './PoemsClient';
 import Navbar from '@/components/Navbar';


### PR DESCRIPTION
Added the 'dynamic' export with value 'force-dynamic' to ensure the archive page is always rendered dynamically. This may be needed for up-to-date data or to avoid caching issues.